### PR TITLE
Switch from deprecated arma::is_finite to std::isfinite

### DIFF
--- a/src/rtoarmadillo.cpp
+++ b/src/rtoarmadillo.cpp
@@ -556,8 +556,8 @@ arma::cube acf(arma::mat& x, int lagmax = 0, bool cor = true, bool demean = true
         
         for(int i = 0; i < nobs-lag; i++){
           
-          if(arma::is_finite(x[i + lag + nobs*u]) &&
-             arma::is_finite(x[i + nobs*v])) {
+          if(std::isfinite(x[i + lag + nobs*u]) &&
+             std::isfinite(x[i + nobs*v])) {
             nu++;
             sum += x[i + lag + nobs*u] * x[i + nobs*v];
           }


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just a single statement. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.